### PR TITLE
fix: Restore CopyToHTTPHeader

### DIFF
--- a/types/header.go
+++ b/types/header.go
@@ -2,6 +2,8 @@ package types
 
 import "net/http"
 
+// TODO_REFACTOR: Move these helper functions to a more appropriate package.
+
 // CopyToHTTPHeader copies the POKTHTTPRequest header map to the httpHeader map.
 func (req *POKTHTTPRequest) CopyToHTTPHeader(httpHeader http.Header) {
 	for key, header := range req.Header {

--- a/types/header.go
+++ b/types/header.go
@@ -1,0 +1,21 @@
+package types
+
+import "net/http"
+
+// CopyToHTTPHeader copies the POKTHTTPRequest header map to the httpHeader map.
+func (req *POKTHTTPRequest) CopyToHTTPHeader(httpHeader http.Header) {
+	for key, header := range req.Header {
+		for _, value := range header.Values {
+			httpHeader.Add(key, value)
+		}
+	}
+}
+
+// CopyToHTTPHeader copies the POKTHTTPResponse header map to the httpHeader map.
+func (req *POKTHTTPResponse) CopyToHTTPHeader(httpHeader http.Header) {
+	for key, header := range req.Header {
+		for _, value := range header.Values {
+			httpHeader.Add(key, value)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Restore `CopyToHTTPHeader` `POKTHTTPRequest` and `POKTHTTPResponse` methods.

## Issue

Restore helper methods needed by AppGateServer that copy `POKTHTTP{Request/Response}` headers to `http.Header`

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
