### PR TITLE
fix: register codec types

### DIFF
--- a/account.go
+++ b/account.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/types"
 	accounttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	grpc "github.com/cosmos/gogoproto/grpc"
@@ -18,6 +19,7 @@ var queryCodec *codec.ProtoCodec
 func init() {
 	reg := cdctypes.NewInterfaceRegistry()
 	accounttypes.RegisterInterfaces(reg)
+	cryptocodec.RegisterInterfaces(reg)
 	queryCodec = codec.NewProtoCodec(reg)
 }
 


### PR DESCRIPTION
## Summary

Register CosmosSDK crypto codecs

## Issue

`PubKey` interface fails to find a registered type. 

![image](https://github.com/pokt-network/shannon-sdk/assets/231488/b9bac512-c843-482d-b30f-1cb80410811a)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
