### PR TITLE
Fix: GetAllApplications sets the Pagination.Limit field to max

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,8 +35,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
-          args: --timeout 10m --verbose
+          version: v1.62.0
+          args: --timeout 20m --verbose
 
       - name: Test
         run: make test_all

--- a/application.go
+++ b/application.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	query "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/pokt-network/poktroll/pkg/crypto/rings"
 	"github.com/pokt-network/poktroll/x/application/types"
 	"github.com/pokt-network/ring-go"
@@ -34,7 +35,12 @@ type ApplicationClient struct {
 func (ac *ApplicationClient) GetAllApplications(
 	ctx context.Context,
 ) ([]types.Application, error) {
-	req := &types.QueryAllApplicationsRequest{}
+	req := &types.QueryAllApplicationsRequest{
+		Pagination: &query.PageRequest{
+			Limit: query.PaginationMaxLimit,
+		},
+	}
+
 	res, err := ac.QueryClient.AllApplications(ctx, req)
 	if err != nil {
 		return []types.Application{}, err

--- a/application.go
+++ b/application.go
@@ -30,6 +30,9 @@ type ApplicationClient struct {
 	types.QueryClient
 }
 
+// TODO_FUTURE(@adshmh): support pagination if/when the number of onchain applications grows enough to cause a performance issue
+// with returning all applications at-once.
+//
 // GetAllApplications returns all applications in the network.
 // TODO_TECHDEBT: Add filtering options to this method once they are supported by the on-chain module.
 func (ac *ApplicationClient) GetAllApplications(


### PR DESCRIPTION
## Summary

This PR fixed the `GetAllApplications` method to set the pagination limit to the maximum value allowed by the Cosmos SDK, to allow returning all onchain applications in a single call.

## Issue

`GetAllApplications` method was only returning the default number of onchain apps in a single call, omitting the rest of the applications from the results.


## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
