### PR TITLE
Enforce context deadline when fetching apps or sessions

### DIFF
--- a/application.go
+++ b/application.go
@@ -93,7 +93,7 @@ func (ac *ApplicationClient) GetApplication(
 		// e.g. using google.golang.org/grpc's MaxCallRecvMsgSize CallOption.
 		res, err := ac.QueryClient.Application(ctx, req)
 		if err != nil {
-			resultCh <- result{types.Application{}, err}
+			resultCh <- result{app: types.Application{}, err: err}
 			return
 		}
 

--- a/session.go
+++ b/session.go
@@ -38,7 +38,7 @@ func (s *SessionClient) GetSession(
 	}
 
 	resultCh := make(chan result, 1)
-	// Launch GetApplication in goroutine
+	// Launch QueryGetSessionRequest in goroutine
 	go func() {
 		req := &sessiontypes.QueryGetSessionRequest{
 			ApplicationAddress: appAddress,

--- a/session.go
+++ b/session.go
@@ -49,15 +49,6 @@ func (s *SessionClient) GetSession(
 		// TODO_TECHDEBT(@adshmh): consider increasing the default response size:
 		// e.g. using google.golang.org/grpc's MaxCallRecvMsgSize CallOption.
 		//
-		// TODO_IMPROVE: Would it be feasible to add a GetCurrentSession, supported by the underlying protocol?
-		//
-		// It seems likely that GetSession will almost always be used to get the session
-		// matching the latest height.
-		//
-		// In addition, the current session that is being returned could:
-		// - Include the latest block height
-		// - Reduce the number of SDK calls needed for sending relays
-		// - Remove the need for the BlockClient
 		res, err := s.PoktNodeSessionFetcher.GetSession(ctx, req)
 		if err != nil {
 			resultCh <- result{err: err}


### PR DESCRIPTION
## Summary

When fetching a single app, all apps, or a session, the supplied context's deadline (if any) is enforced:
`GetApplication`, `GetAllApplications`, and `GetSession` will return an error as soon as the supplied context's deadline is exceeded, without waiting for the full node's response.

## Issue

Without this fix, users of the SDK need to write custom code for forcing the desired deadline, even though it is passed to the SDK in a `context.Context`.

- #{ISSUE_NUMBER}

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
