### PR TITLE
Bump go version from `v1.23.0` to `v.1.24.3`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+# Run `asdf plugin add golang` and `asdf install` to install the dependencies,
+# and `asdf current` to switch to the versions of dependencies listed below
+golang 1.24.3
+go 1.24.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pokt-network/shannon-sdk
 
-go 1.23.0
+go 1.24.3
 
 // DEV_NOTE: Uncomment the line below to use a local version of poktroll if there's
 // a need to use new gRPC methods or protobufs that have not been released yet.

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,6 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-network/poktroll v0.0.14-0.20250326175118-1f32ed729121 h1:/3LeyNtHE1sr7LWbpnjmLbX10EzXvNzmFp39LYHdsfA=
-github.com/pokt-network/poktroll v0.0.14-0.20250326175118-1f32ed729121/go.mod h1:UHqzNY4PuCgNw9CDA01UIyuT0zNllxWJ0Nr+MKopcwQ=
 github.com/pokt-network/poktroll v0.1.0 h1:cdImshb6aD3f4AXxnPjJJRKE7nHdd5fthBWLfjEdmWw=
 github.com/pokt-network/poktroll v0.1.0/go.mod h1:UHqzNY4PuCgNw9CDA01UIyuT0zNllxWJ0Nr+MKopcwQ=
 github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTjKSSwk=


### PR DESCRIPTION
Necessary to align with the changes here: https://github.com/pokt-network/poktroll/pull/1307