### PR TITLE
[Bug] Add nil check in ValidateRelayResponse's call to publicKeyFetcher.GetPubKeyFromAddress to avoid panic in PATH

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -92,6 +92,8 @@ func ValidateRelayResponse(
 	if err != nil {
 		return nil, err
 	}
+
+	// This can happen if a supplier has never been used (e.g. funded) onchain
 	if supplierPubKey == nil {
 		return nil, fmt.Errorf("ValidateRelayResponse: supplier public key is nil for address %s", string(supplierAddress))
 	}

--- a/relay.go
+++ b/relay.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	cosmossdk "github.com/cosmos/cosmos-sdk/types"
@@ -90,6 +91,9 @@ func ValidateRelayResponse(
 	)
 	if err != nil {
 		return nil, err
+	}
+	if supplierPubKey == nil {
+		return nil, fmt.Errorf("ValidateRelayResponse: supplier public key is nil for address %s", string(supplierAddress))
 	}
 
 	if signatureErr := relayResponse.VerifySupplierOperatorSignature(supplierPubKey); signatureErr != nil {


### PR DESCRIPTION
## 🌿 Summary

Prevent `nil` pointer panic in `ValidateRelayResponse` by adding a check for a missing public key.

## 👀 Origin

**tl;dr it appears the Cosmos SDK method `GetPubKey() cryptotypes.PubKey // can return nil.` was indeed returning nil.**

Was getting the following panic in PATH when running locally during load tests:
```bash
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x50 pc=0x105b73bac]

goroutine 611 [running]:
github.com/pokt-network/poktroll/x/service/types.(*RelayResponse).VerifySupplierOperatorSignature(0x1400122e900, {0x0, 0x0})
        /Users/pascal/go/pkg/mod/github.com/pokt-network/poktroll@v0.1.13/x/service/types/relay.go:120 +0x15c
github.com/pokt-network/shannon-sdk.ValidateRelayResponse({0x10869c3b0, 0x10ab0a960}, {0x14001d60300, 0x2b}, {0x140013e6000, 0x35b, 0x380}, {0x1086487e0, 0x14001123cf0})
        /Users/pascal/grove/shannon-sdk/relay.go:104 +0x174
github.com/buildwithgrove/path/protocol/shannon.(*lazyFullNode).ValidateRelayResponse(...)
        /Users/pascal/grove/path/protocol/shannon/fullnode_lazy.go:122
github.com/buildwithgrove/path/protocol/shannon.(*cachingFullNode).ValidateRelayResponse(0x10869c490?, {0x14001d60300?, 0x14001d60330?}, {0x140013e6000?, 0x14001d759f0?, 0x14001d20c00?})
        /Users/pascal/grove/path/protocol/shannon/fullnode_cache.go:176 +0x58
github.com/buildwithgrove/path/protocol/shannon.(*requestContext).sendRelay(0x140003f62a0, {{0x14001367880, 0x36}, {0x10747d1b0, 0x4}, {0x0, 0x0}, 0x2710})
        /Users/pascal/grove/path/protocol/shannon/context.go:205 +0x3ac
github.com/buildwithgrove/path/protocol/shannon.(*requestContext).HandleServiceRequest(0x140003f62a0, {{0x14001367880, 0x36}, {0x10747d1b0, 0x4}, {0x0, 0x0}, 0x2710})
        /Users/pascal/grove/path/protocol/shannon/context.go:77 +0x88
github.com/buildwithgrove/path/gateway.(*requestContext).HandleRelayRequest(0x140003fe100)
        /Users/pascal/grove/path/gateway/request_context.go:252 +0xbc
github.com/buildwithgrove/path/gateway.(*EndpointHydrator).performChecks.func1()
        /Users/pascal/grove/path/gateway/hydrator.go:208 +0x3b4
created by github.com/buildwithgrove/path/gateway.(*EndpointHydrator).performChecks in goroutine 372
        /Users/pascal/grove/path/gateway/hydrator.go:156 +0x294
make: *** [path_run] Error 2
```

### 🌱 Primary Changes:
- Added a `nil` check for `supplierPubKey` in `ValidateRelayResponse`
- Return a descriptive error if the public key is missing for a given address

## 🛠️ Type of change

- [x] Bug fix